### PR TITLE
Fixed Unity Version Warning in Creator Companion v2.2.x and newer.

### DIFF
--- a/Packages/net.markcreator.sizeprofiler/package.json
+++ b/Packages/net.markcreator.sizeprofiler/package.json
@@ -3,6 +3,7 @@
   "displayName": "SizeProfiler",
   "version": "1.2.1",
   "description": "An interface that lets you inspect any object in Unity and find its dependencies and file size breakdown.",
+  "unity": "2019.4",
   "gitDependencies": {},
   "vpmDependencies": {},
   "legacyFolders": {},


### PR DESCRIPTION
In the latest Creator Companion versions that introduced support for Unity 2022, a new function was added that allows the VCC to read what Unity version the said Package supports.

**SizeProfiler** currently does not have a `"unity"` declaration in the `package.json`. This causes a Warning to the user when they attempt to add your package, stating, _"Package does not declare a minimum Unity version. It may not function correctly."_ This requires the user's input to confirm adding your Package.

This Pull Request fixes that. I've added the declaration `"unity": "2019.4"` to your `package.json` so that the Warning no longer appears when added to a project. I'm not sure if you plan to make new changes to SizeProfiler anytime soon. But just in case, I recommend merging this Pull Request before the next update.

**NOTE TO MARK:** I did not bump the package `"version"` number whatsoever. I prefer that you handle that part on your side.

Thanks!